### PR TITLE
Update known key constants

### DIFF
--- a/g13_keys.hpp
+++ b/g13_keys.hpp
@@ -11,8 +11,8 @@
 namespace G13 {
 // static std::vector<std::string> G13_KEY_STRINGS;
 
-/*! sequence containing the
- * G13 keys.  The order is very specific, with the position of each
+/*! sequence containing the G13 keys.
+ * The order is very specific, with the position of each
  * item corresponding to a specific bit in the G13's USB message
  * format.  Do NOT remove or insert items in this list.
  */
@@ -31,37 +31,35 @@ static const char* G13_KEY_STRINGS[] = {  // formerly G13_KEY_SEQ
 };
 // clang-format on
 
-/*! sequence containing the
- * G13 keys that shouldn't be tested input.  These aren't actually keys,
- * but they are in the bitmap defined by G13_KEY_SEQ.
+/*! sequence containing the G13 keys that shouldn't be tested input.
+ * These aren't actually keys, but they are in the bitmap defined by G13_KEY_SEQ.
  */
 // formerly G13_NONPARSED_KEY_SEQ
-static const char *G13_NONPARSED_KEYS[] = {
-    "UNDEF1", "LIGHT_STATE", "UNDEF3",     "LIGHT",
-    "LIGHT2", "UNDEF3",      "MISC_TOGGLE"};
+static const char* G13_NONPARSED_KEYS[] = {
+  "UNDEF1", "LIGHT_STATE", "UNDEF3", "LIGHT", "LIGHT2", "MISC_TOGGLE"
+};
 
-/*! sequence containing the
- * names of keyboard keys we can send through binding actions.
- * These correspond to KEY_xxx value definitions in <linux/input.h>,
+/*! sequence containing the names of keyboard keys we can send through binding
+ * actions. These correspond to KEY_xxx value definitions in <linux/input.h>,
  * i.e. ESC is KEY_ESC, 1 is KEY_1, etc.
+ *
+ * Note: later found in <linux/input-event-codes.h>
  */
 // formerly KB_INPUT_KEY_SEQ
 // clang-format off
-static const char*  G13_SYMBOLS[] = {
-  "ESC", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "MINUS", "EQUAL", "BACKSPACE",
-  "TAB", "Q", "W", "E", "R", "T", "Y", "U", "I", "O",
-  "P", "LEFTBRACE", "RIGHTBRACE", "ENTER", "LEFTCTRL", "RIGHTCTRL", "A", "S", "D", "F",
-  "G", "H", "J", "K", "L", "SEMICOLON",
-  "APOSTROPHE", "GRAVE", "LEFTSHIFT", "BACKSLASH", "Z", "X", "C", "V", "B", "N", "M",
-  "COMMA", "DOT", "SLASH", "RIGHTSHIFT",
-  "KPASTERISK", "LEFTALT", "RIGHTALT", "SPACE", "CAPSLOCK", "F1", "F2", "F3", "F4", "F5",
-  "F6", "F7", "F8", "F9", "F10", "F11", "F12",
-  "NUMLOCK", "SCROLLLOCK", "KP7", "KP8", "KP9", "KPMINUS", "KP4", "KP5", "KP6", "KPPLUS",
-  "KP1", "KP2", "KP3", "KP0", "KPDOT",
-  "KPSLASH", "LEFT", "RIGHT", "UP", "DOWN", "PAGEUP", "PAGEDOWN", "HOME", "END", "INSERT",
-  "DELETE", "F13", "F14", "F15", "F16",
-  "F17", "F18", "F19", "F20", "F21", "F22", "F23", "F24", "NEXTSONG", "PLAYPAUSE",
-  "PREVIOUSSONG"
+static const char* G13_SYMBOLS[] = {
+  "ESC", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
+  "F13", "F14", "F15", "F16", "F17", "F18", "F19", "F20", "F21", "F22", "F23", "F24",
+  "GRAVE", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "MINUS", "EQUAL", "BACKSPACE",
+  "TAB", "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P", "LEFTBRACE", "RIGHTBRACE" ,"BACKSLASH",
+  "CAPSLOCK", "A", "S", "D", "F", "G", "H", "J", "K", "L", "SEMICOLON", "APOSTROPHE", "ENTER",
+  "LEFTSHIFT", "Z", "X", "C", "V", "B", "N", "M", "COMMA", "DOT", "SLASH", "RIGHTSHIFT",
+  "LEFTCTRL", "LEFTMETA", "LEFTALT", "SPACE", "RIGHTALT", "RIGHTCTRL",
+  "PAGEUP", "PAGEDOWN", "HOME", "END", "INSERT", "DELETE", "LEFT", "RIGHT", "UP", "DOWN",
+  "NUMLOCK", "SCROLLLOCK", "BREAK", "BACK", "FORWARD", "SCREENLOCK",
+  "KP7", "KP8", "KP9", "KP4", "KP5", "KP6", "KP1", "KP2", "KP3", "KP0",
+  "KPDOT", "KPSLASH", "KPASTERISK", "KPMINUS",  "KPPLUS", "KPENTER",
+  "PREVIOUSSONG", "NEXTSONG", "STOP", "PLAYPAUSE", "MUTE", "VOLUMEDOWN", "VOLUMEUP"
 };
 // clang-format on
 


### PR DESCRIPTION
Add additional constants for media control and others. Reorder to be more inline with a standard keyboard layout, should be a little easier to read